### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/tehmiaddison/e12e9ba1-abe9-4a70-a73e-211a3879cabb/afcef9dd-b439-48c1-bf96-9597cfd31eeb/_apis/work/boardbadge/0785ea47-934b-4413-aba0-7f993001de85)](https://dev.azure.com/tehmiaddison/e12e9ba1-abe9-4a70-a73e-211a3879cabb/_boards/board/t/afcef9dd-b439-48c1-bf96-9597cfd31eeb/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#167](https://dev.azure.com/tehmiaddison/e12e9ba1-abe9-4a70-a73e-211a3879cabb/_workitems/edit/167). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.